### PR TITLE
add GitHub Actions workflow for PyPI releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      # Required for trusted publishing to PyPI
+      id-token: write
+      # Required to upload artifacts to the release
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        # Fetch all history and tags for hatch-vcs to determine version
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+      with:
+        enable-cache: true
+
+    - name: Build package
+      run: uv build
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        print-hash: true
+
+    - name: Upload build artifacts to release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh release upload ${{ github.ref_name }} dist/*


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml` triggered on GitHub Release publish
- Uses PyPI trusted publishing (no API tokens needed)
- Builds with `uv build`, publishes via `pypa/gh-action-pypi-publish`
- Uploads sdist/wheel artifacts to the GitHub Release

## Context

This is PR 4 of 5 decomposing #3 into reviewable pieces.

## Post-merge setup

Configure trusted publishing on PyPI:
1. Go to https://pypi.org/manage/project/rhcalendar/settings/publishing/
2. Add trusted publisher: owner `ktdreyer`, repo `rhcalendar`, workflow `release.yml`

## Test plan

- [ ] YAML is valid (workflow syntax check)
- [ ] After merge, create a test GitHub Release to verify end-to-end