### PR TITLE
add bump-my-version configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,13 @@ include = [
     "README.md",
     "LICENSE",
 ]
+
+[tool.bumpversion]
+current_version = "1.3.6"
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
+serialize = ["{major}.{minor}.{patch}"]
+commit = true
+tag = true
+tag_name = "v{new_version}"
+tag_message = "version {new_version}"
+message = "bump version to {new_version}"


### PR DESCRIPTION
## Summary

- Add `[tool.bumpversion]` config to `pyproject.toml`
- Configured for semantic versioning with `v`-prefixed git tags
- Usage: `bump-my-version bump patch` (or `minor`/`major`)

## Context

This is PR 3 of 5 decomposing #3 into reviewable pieces. Depends on #4.

## Test plan

- [ ] `bump-my-version bump patch --dry-run` shows correct behavior