### PR TITLE
switch to hatch-vcs for dynamic versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 build/*
 dist/*
 doc/build/*
+rhcalendar/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "rhcalendar"
+dynamic = ["version"]
 description = "Red Hat business days calendar"
-version = "1.3.6"
 authors = [
     {name = "Ken Dreyer", email = "ktdreyer@ktdreyer.com"},
 ]
@@ -29,6 +29,12 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/ktdreyer/rhcalendar"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "rhcalendar/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["rhcalendar"]

--- a/rhcalendar/__init__.py
+++ b/rhcalendar/__init__.py
@@ -4,7 +4,10 @@ import workdays  # type: ignore[import-untyped]
 
 from rhcalendar.locales import locales
 
-__version__ = '1.3.6'
+try:
+    from rhcalendar._version import __version__
+except ImportError:
+    __version__ = "0.0.0+unknown"
 
 
 def networkdays(from_date: datetime.date, to_date: datetime.date,

--- a/rhcalendar/tests/test_init.py
+++ b/rhcalendar/tests/test_init.py
@@ -8,9 +8,10 @@ def test_init():
 def test_version_fallback(monkeypatch):
     """ When _version.py is missing, __version__ falls back gracefully. """
     import importlib
+    import sys
     import rhcalendar
-    monkeypatch.setitem(
-        __import__('sys').modules, 'rhcalendar._version', None
-    )
+    with monkeypatch.context() as m:
+        m.setitem(sys.modules, "rhcalendar._version", None)
+        importlib.reload(rhcalendar)
+        assert rhcalendar.__version__ == "0.0.0+unknown"
     importlib.reload(rhcalendar)
-    assert rhcalendar.__version__ == "0.0.0+unknown"

--- a/rhcalendar/tests/test_init.py
+++ b/rhcalendar/tests/test_init.py
@@ -3,3 +3,14 @@ from rhcalendar import networkdays
 
 def test_init():
     assert networkdays
+
+
+def test_version_fallback(monkeypatch):
+    """ When _version.py is missing, __version__ falls back gracefully. """
+    import importlib
+    import rhcalendar
+    monkeypatch.setitem(
+        __import__('sys').modules, 'rhcalendar._version', None
+    )
+    importlib.reload(rhcalendar)
+    assert rhcalendar.__version__ == "0.0.0+unknown"


### PR DESCRIPTION
## Summary

- Add `hatch-vcs` to derive version from git tags automatically
- Replace hardcoded `__version__ = '1.3.6'` with dynamic import from generated `_version.py`
- Gitignore the generated `_version.py` (build artifact)

## Context

This is PR 2 of 5 decomposing #3 into reviewable pieces. Depends on #4.

## Test plan

- [ ] `uv build` succeeds and produces correct version in the built package
- [ ] `python -c "from rhcalendar import __version__; print(__version__)"` prints the version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched project to derive version automatically from VCS with a fallback for unknown builds; generated version artifact is now ignored from source control.
* **Tests**
  * Added a test to verify the fallback version is used when the generated version artifact is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->